### PR TITLE
NDWH-2138: Airflow 2.x compatibility

### DIFF
--- a/etc/requirements.dev.txt
+++ b/etc/requirements.dev.txt
@@ -1,5 +1,5 @@
 # Airflow
-apache-airflow[crypto,celery,postgres,s3,ssh,sendgrid]==1.10.14
+apache-airflow==2.2.0
 Flask~=1.1.2
 Flask-SQLAlchemy~=2.5.1
 SQLAlchemy~=1.3.8

--- a/src/dags/airflow_clear_missing_dags.py
+++ b/src/dags/airflow_clear_missing_dags.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 
 from airflow.models import DAG, DagModel
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.db import provide_session
 
 
@@ -49,6 +49,8 @@ def clear_missing_dags(session=None, **context):
         log.info(f'Deleting {len(entries_to_delete)} DAG(s) from the DB')
         for entry in entries_to_delete:
             session.delete(entry)
+            if entry.serialized_dag:
+                session.delete(entry.serialized_dag)
 
         session.commit()
         log.info('All missing DAG(s) have been cleared')

--- a/src/dags/airflow_db_cleanup.py
+++ b/src/dags/airflow_db_cleanup.py
@@ -6,11 +6,10 @@ from datetime import datetime, timedelta
 
 import dateutil.parser
 from airflow.models import DAG, DagRun, Log, XCom, TaskInstance, Variable
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils import timezone
 from airflow.utils.db import provide_session
 from sqlalchemy import func, and_
-from sqlalchemy.orm import load_only
 
 import settings
 
@@ -82,9 +81,7 @@ def cleanup_function(db_class, session=None, **context):
     keep_last_group_by = DATABASE_OBJECTS[db_class].get('keep_last_group_by')
 
     log.info(f'Clearing Airflow DB table of model: {str(airflow_db_model.__name__)} before {max_date.isoformat()}')
-    query = session.query(airflow_db_model).options(
-        load_only(age_check_column),
-    )
+    query = session.query(airflow_db_model)
 
     if keep_last:
         subquery = session.query(func.max(DagRun.execution_date))

--- a/src/dags/airflow_db_cleanup.py
+++ b/src/dags/airflow_db_cleanup.py
@@ -15,36 +15,37 @@ from sqlalchemy.orm import load_only
 import settings
 
 # List of all the objects that will be deleted. Comment out the DB objects you want to skip.
-DATABASE_OBJECTS = [
-    {
+DATABASE_OBJECTS = {
+    'DagRun': {
         'airflow_db_model': DagRun,
         'age_check_column': DagRun.execution_date,
         'keep_last': True,
         'keep_last_filters': [DagRun.external_trigger.is_(False)],
         'keep_last_group_by': DagRun.dag_id,
     },
-    {
+    'TaskInstance': {
         'airflow_db_model': TaskInstance,
         'age_check_column': TaskInstance.execution_date,
         'keep_last': False,
         'keep_last_filters': None,
         'keep_last_group_by': None,
     },
-    {
+    'Log': {
         'airflow_db_model': Log,
         'age_check_column': Log.dttm,
         'keep_last': False,
         'keep_last_filters': None,
         'keep_last_group_by': None,
     },
-    {
+    # XCom can have a custom class, and it's usually an alias for BaseXCom, so don't hard-code this name
+    XCom.__name__: {
         'airflow_db_model': XCom,
         'age_check_column': XCom.execution_date,
         'keep_last': False,
         'keep_last_filters': None,
         'keep_last_group_by': None,
     },
-]
+}
 
 
 def get_max_days(**context):
@@ -62,10 +63,11 @@ def get_max_days(**context):
 
 
 @provide_session
-def cleanup_function(session=None, **context):
+def cleanup_function(db_class, session=None, **context):
     """
     Clears the Airflow DB of the Model specified in the context parameter `airflow_db_model` before the `max_date`
 
+    :param db_class: The name of the class to clean up
     :param session: Airflow session used to query objects to delete
     :param context: context within the Airflow DAG
     """
@@ -73,11 +75,11 @@ def cleanup_function(session=None, **context):
     max_date = context['ti'].xcom_pull(key='max_date')
     max_date = dateutil.parser.parse(max_date)  # stored as iso8601 str in xcom
 
-    airflow_db_model = context['params'].get('airflow_db_model')
-    age_check_column = context['params'].get('age_check_column')
-    keep_last = context['params'].get('keep_last')
-    keep_last_filters = context['params'].get('keep_last_filters')
-    keep_last_group_by = context['params'].get('keep_last_group_by')
+    airflow_db_model = DATABASE_OBJECTS[db_class].get('airflow_db_model')
+    age_check_column = DATABASE_OBJECTS[db_class].get('age_check_column')
+    keep_last = DATABASE_OBJECTS[db_class].get('keep_last')
+    keep_last_filters = DATABASE_OBJECTS[db_class].get('keep_last_filters')
+    keep_last_group_by = DATABASE_OBJECTS[db_class].get('keep_last_group_by')
 
     log.info(f'Clearing Airflow DB table of model: {str(airflow_db_model.__name__)} before {max_date.isoformat()}')
     query = session.query(airflow_db_model).options(
@@ -121,10 +123,12 @@ with DAG(
         provide_context=True,
         python_callable=get_max_days,
     )
-    for db_object in DATABASE_OBJECTS:
+    for db_object_name in DATABASE_OBJECTS:
         calc_max_date >> PythonOperator(
-            task_id=f"cleanup_{str(db_object['airflow_db_model'].__name__)}",
+            task_id=f"cleanup_{db_object_name}",
             python_callable=cleanup_function,
-            params=db_object,
+            op_kwargs={
+                'db_class': db_object_name
+            },
             provide_context=True,
         )

--- a/src/dags/airflow_kill_halted_tasks.py
+++ b/src/dags/airflow_kill_halted_tasks.py
@@ -11,7 +11,7 @@ from typing import NamedTuple
 
 import pytz
 from airflow.models import DAG, DagModel, DagRun, TaskInstance
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.db import provide_session
 from sqlalchemy import and_
 

--- a/src/dags/airflow_log_cleanup.py
+++ b/src/dags/airflow_log_cleanup.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
+from airflow.operators.python import PythonOperator, ShortCircuitOperator
 
 import settings
 

--- a/test/dags/test_airflow_db_cleanup.py
+++ b/test/dags/test_airflow_db_cleanup.py
@@ -337,8 +337,8 @@ def make_airflow_objects():
 @pytest.mark.usefixtures('make_airflow_objects')
 @pytest.mark.parametrize(
     'obj',
-    [pytest.param(obj, id=f'{obj["airflow_db_model"].__name__}, print') for obj in DATABASE_OBJECTS] +
-    [pytest.param(obj, id=f'{obj["airflow_db_model"].__name__}, no print') for obj in DATABASE_OBJECTS]
+    [pytest.param(obj, id=f'{class_name}, print') for class_name, obj in DATABASE_OBJECTS.items()] +
+    [pytest.param(obj, id=f'{class_name}, no print') for class_name, obj in DATABASE_OBJECTS.items()]
 )
 @provide_session
 def test_airflow_db_cleanup(obj, session=None):
@@ -373,7 +373,7 @@ def test_airflow_db_cleanup(obj, session=None):
 
 
 @pytest.mark.usefixtures('make_airflow_objects')
-@pytest.mark.parametrize('obj', [pytest.param(obj, id=obj["airflow_db_model"].__name__) for obj in DATABASE_OBJECTS])
+@pytest.mark.parametrize('obj', [pytest.param(obj, id=class_name) for class_name, obj in DATABASE_OBJECTS.items()])
 @provide_session
 def test_airflow_db_cleanup_no_delete(obj, session=None):
     airflow_db_model = obj['airflow_db_model']

--- a/test/dags/test_airflow_log_cleanup.py
+++ b/test/dags/test_airflow_log_cleanup.py
@@ -4,12 +4,12 @@ from datetime import datetime
 import pytest
 from airflow.models import TaskInstance, XCom, DagRun
 from airflow.utils.state import State
-from pendulum import Pendulum
+from pendulum import DateTime, UTC
 
 import settings
 from dags.airflow_log_cleanup import log_cleanup_dag, XCOM_LOG_FILES_KEY
 
-EXECUTION_DATE = Pendulum(2020, 7, 18, 6)
+EXECUTION_DATE = DateTime(2020, 7, 18, 6, tzinfo=UTC)
 
 
 def create_file_with_st_mtime(py_fake_fs, full_path, dt):
@@ -20,8 +20,8 @@ def create_file_with_st_mtime(py_fake_fs, full_path, dt):
     f.stat_result._st_mtime_ns = dt.timestamp() * 1e9  # nanoseconds
 
 
-@pytest.fixture(scope='module')
-def dagrun():
+@pytest.fixture()
+def dagrun(airflow_session):
     dag_run = log_cleanup_dag.create_dagrun(
         run_id=f'test_airflow_log_cleanup__{datetime.utcnow()}',
         execution_date=EXECUTION_DATE,


### PR DESCRIPTION
These changes are presently needed for AFM, but AEM is not ready for them yet. Before we merge this PR, we should probably add a tag to the version currently being pulled by AEM.

The thing that's causing a problem in AFM currently is the fact that it can't store the airflow_cleanup_db DAG in the `SerializedDagModel` table, because the params for most of the tasks are not JSON-serializable. After doing that, I updated the test suite to check for any other problems that might exist.

@ccramer3 please make note of the changes I made to test data to double-check that I didn't accidentally remove any test cases.