### PR TITLE
Feature/ndwh 3813 deadlock on cleanup dag

### DIFF
--- a/etc/requirements.dev.txt
+++ b/etc/requirements.dev.txt
@@ -1,13 +1,13 @@
 # Airflow
-apache-airflow==2.2.0
-Flask~=1.1.2
+apache-airflow~=2.10.0
+Flask~=2.2.5
 Flask-SQLAlchemy~=2.5.1
-SQLAlchemy~=1.3.8
+SQLAlchemy~=1.4.52
 
 # Testing
-pytest~=6.2.2
-pytest-cov~=2.11.1
-pytest-mock~=3.5.1
-pyfakefs~=4.4.0
-moto~=2.0.4
-testfixtures~=6.18.1
+pytest~=8.3.4
+pytest-cov~=6.0.0
+pytest-mock~=3.14.0
+pyfakefs~=5.7.2
+moto~=5.0.22
+testfixtures~8.3.0

--- a/src/maintenance_dags/airflow_db_cleanup.py
+++ b/src/maintenance_dags/airflow_db_cleanup.py
@@ -18,13 +18,6 @@ DATABASE_OBJECTS = {
     'DagRun': {
         'airflow_db_model': DagRun,
         'age_check_column': DagRun.execution_date,
-        'keep_last': True,
-        'keep_last_filters': [DagRun.external_trigger.is_(False)],
-        'keep_last_group_by': DagRun.dag_id,
-    },
-    'TaskInstance': {
-        'airflow_db_model': TaskInstance,
-        'age_check_column': TaskInstance.execution_date,
         'keep_last': False,
         'keep_last_filters': None,
         'keep_last_group_by': None,
@@ -121,7 +114,7 @@ with DAG(
         python_callable=get_max_days,
     )
     for db_object_name in DATABASE_OBJECTS:
-        calc_max_date >> PythonOperator(
+        db_cleanup_dag.leaves >> PythonOperator(
             task_id=f"cleanup_{db_object_name}",
             python_callable=cleanup_function,
             op_kwargs={

--- a/test/dags/test_airflow_clear_missing_dags.py
+++ b/test/dags/test_airflow_clear_missing_dags.py
@@ -1,9 +1,9 @@
 import os
-from datetime import datetime
 
 import pytest
-from airflow.models import TaskInstance, DagModel
+from airflow.models import TaskInstance, DagModel, DagRun
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 from pendulum import DateTime, UTC
 
 from maintenance_dags.airflow_clear_missing_dags import clear_missing_dags_dag
@@ -37,13 +37,13 @@ DAG_CONFIGS = {
 
 
 @pytest.fixture()
-def dagrun(airflow_session):
-    dag_run = clear_missing_dags_dag.create_dagrun(
-        run_id=f'test_airflow_db_cleanup__{datetime.utcnow()}',
+def dag_run(airflow_session) -> DagRun:
+    return clear_missing_dags_dag.create_dagrun(
+        run_type=DagRunType.SCHEDULED,
         execution_date=EXECUTION_DATE,
         state=State.RUNNING,
+        session=airflow_session
     )
-    return dag_run
 
 
 @pytest.fixture
@@ -63,10 +63,10 @@ def prepare_missing_dags(fs, airflow_session):
 
 
 @pytest.mark.usefixtures('prepare_missing_dags')
-def test_clear_missing_dags(airflow_session, dagrun):
+def test_clear_missing_dags(airflow_session, dag_run):
     ti = TaskInstance(
-        task=dagrun.dag.get_task('clear_missing_dags'),
-        execution_date=dagrun.execution_date,
+        task=dag_run.dag.get_task('clear_missing_dags'),
+        execution_date=dag_run.execution_date,
     )
     ti.set_state(State.NONE)
     ti.run(ignore_all_deps=True)

--- a/test/dags/test_airflow_db_cleanup.py
+++ b/test/dags/test_airflow_db_cleanup.py
@@ -116,7 +116,7 @@ AIRFLOW_DATA = [
         execution_date=cleanup_threshold.subtract(days=2),
         run_id='dag3_run1',
         external_trigger=False,
-    ), True),
+    ), False),
     # dag_4: One triggered run, old
     (DagRun, dict(
         dag_id='dag_4',
@@ -192,7 +192,7 @@ AIRFLOW_DATA = [
         execution_date=dropped_midnight.subtract(hours=12),
         run_id='dag7_run2',
         external_trigger=False,
-    ), True),
+    ), False),
     # The other types just filter based on one column, without any special conditions to keep items
     # TaskInstance; make sure each one matches a DagRun above
     # Note that each task will automatically be added to the DAG during test setup,

--- a/test/dags/test_airflow_db_cleanup.py
+++ b/test/dags/test_airflow_db_cleanup.py
@@ -1,11 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from airflow import DAG
+from airflow.exceptions import TaskNotFound
 from airflow.models import TaskInstance, XCom, Variable, DagRun, Log
-from airflow.operators.dummy import DummyOperator
-from airflow.utils.db import provide_session, create_session
-from airflow.utils.state import State
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.state import State, DagRunState
 from airflow.utils.types import DagRunType
 from dateutil.parser import parse
 from pendulum import DateTime, UTC
@@ -13,13 +13,13 @@ from pendulum import DateTime, UTC
 from maintenance_dags.airflow_db_cleanup import db_cleanup_dag, DATABASE_OBJECTS
 from test import DateTimeRange
 
-EXECUTION_DATE = DateTime(2020, 7, 18, 6, tzinfo=UTC)
+EXECUTION_DATE = DateTime(2023, 7, 18, 6, tzinfo=UTC)
 
 
 @pytest.fixture()
-def dagrun(airflow_session):
+def dag_run(airflow_session):
     dag_run = db_cleanup_dag.create_dagrun(
-        run_id=f'test_airflow_db_cleanup__{datetime.utcnow()}',
+        run_type=DagRunType.SCHEDULED,
         execution_date=EXECUTION_DATE,
         state=State.RUNNING,
     )
@@ -27,13 +27,11 @@ def dagrun(airflow_session):
 
 
 @pytest.fixture
-def clear_variables():
+def clear_variables(airflow_session):
     """Clear variables for this test and the next"""
-    with create_session() as session:
-        session.query(Variable).delete()
+    airflow_session.query(Variable).delete()
     yield
-    with create_session() as session:
-        session.query(Variable).delete()
+    airflow_session.query(Variable).delete()
 
 
 @pytest.mark.usefixtures('clear_variables')
@@ -41,7 +39,7 @@ def clear_variables():
     pytest.param(True, id='Use variable'),
     pytest.param(False, id='Use settings')
 ])
-def test_get_max_days(mocker, dagrun, use_variable):
+def test_get_max_days(mocker, dag_run, use_variable):
     variable_value = 5
     setting_value = 10
 
@@ -211,6 +209,16 @@ AIRFLOW_DATA = [
     ), False),
     (TaskInstance, dict(
         task_id='task_7',
+        dag_id='dag_5',
+        execution_date=dropped_midnight,
+    ), False),
+    (TaskInstance, dict(
+        task_id='task_7',
+        dag_id='dag_5',
+        execution_date=dropped_midnight.add(days=1),
+    ), True),
+    (TaskInstance, dict(
+        task_id='task_7',
         dag_id='dag_1',
         execution_date=cleanup_threshold.add(days=1)
     ), True),
@@ -253,103 +261,114 @@ AIRFLOW_DATA = [
         key='abc',
         value=34567,
         execution_date=dropped_midnight.subtract(days=1),
-        dag_id='dag_1',
-        task_id='task_1',
+        dag_id='dag_5',
+        task_id='task_7',
     ), False),
     (XCom, dict(
         key='abc',
         value=23456,
         execution_date=dropped_midnight,
-        dag_id='dag_1',
-        task_id='task_1',
+        dag_id='dag_5',
+        task_id='task_7',
     ), False),
     (XCom, dict(
         key='abc',
         value=12345,
         execution_date=dropped_midnight.add(days=1),
-        dag_id='dag_1',
-        task_id='task_1',
+        dag_id='dag_5',
+        task_id='task_7',
     ), True),
 ]
 
 
 @pytest.fixture
-def make_airflow_objects():
-    with create_session() as session:
-        session.query(DagRun).delete()
-        session.query(Log).delete()
-        session.query(TaskInstance).delete()
-        session.query(XCom).delete()
+def make_airflow_objects(dag_run, airflow_session):
+    # First, the XCom read by cleanup tasks
+    XCom.set(
+        key='max_date',
+        value=cleanup_threshold.isoformat(),
+        task_id='calculate_max_date',
+        dag_id=db_cleanup_dag.dag_id,
+        run_id=dag_run.run_id,
+        session=airflow_session,
+    )
 
-        # Create a DagModel entry for each dag_id
-        dags = {
-            dag_id: DAG(dag_id=dag_id, start_date=dropped_midnight.subtract(years=1))
-            for dag_id in {obj['dag_id'] for _, obj, _ in AIRFLOW_DATA}
-        }
-        for dag in dags.values():
-            dag.sync_to_db(session=session)
+    # Due to foreign key constraints, we need to make DagModels, then DagRuns, then TaskInstances, then XComs
 
-        # Create DagRun entries
-        session.add_all([DagRun(**obj_data, run_type=DagRunType.MANUAL if obj_data['external_trigger'] else DagRunType.SCHEDULED) for obj_class, obj_data, _ in AIRFLOW_DATA if obj_class is DagRun])
+    # Create a DagModel entry for each dag_id
+    dags = {
+        dag_id: DAG(dag_id=dag_id, start_date=dropped_midnight.subtract(years=1))
+        for dag_id in {obj['dag_id'] for _, obj, _ in AIRFLOW_DATA}
+    }
+    for dag in dags.values():
+        dag.sync_to_db(session=airflow_session)
 
-        # First, the XCom read by these tasks
-        XCom.set(
-            key='max_date',
-            value=cleanup_threshold.isoformat(),
-            execution_date=EXECUTION_DATE,
-            task_id='calculate_max_date',
-            dag_id=db_cleanup_dag.dag_id,
+    # Create DagRun entries
+    dag_runs = [obj_data.copy() for obj_class, obj_data, _ in AIRFLOW_DATA if obj_class is DagRun]
+    for dag_run_args in dag_runs:
+        dag_id = dag_run_args.pop('dag_id')
+        dags[dag_id].create_dagrun(
+            **dag_run_args,
+            run_type=DagRunType.MANUAL if dag_run_args['external_trigger'] else DagRunType.SCHEDULED,
+            state=DagRunState.SUCCESS,
+            session=airflow_session
         )
 
-        # Use XCom.set to handle value serialization
-        xcoms = [obj_data for obj_class, obj_data, _ in AIRFLOW_DATA if obj_class is XCom]
-        for xcom in xcoms:
-            XCom.set(**xcom, session=session)
+    # TaskInstance and Log have custom constructors
+    def make_ti(dag_id, task_id, execution_date):
+        try:
+            task = dags[dag_id].get_task(task_id)
+        except TaskNotFound:
+            task = EmptyOperator(task_id=task_id, dag=dags[dag_id])
+        run_id = airflow_session.query(DagRun.run_id).filter(  # noqa -- Don't care about name shadowing
+            DagRun.dag_id == dag_id,
+            DagRun.execution_date == execution_date,
+        ).scalar()
+        return TaskInstance(
+            task=task,
+            run_id=run_id,
+        )
 
-        # TaskInstance and Log have custom constructors
-        def make_ti(ti_data):
-            task = DummyOperator(task_id=ti_data['task_id'], dag=dags[ti_data['dag_id']])
-            return TaskInstance(
-                task=task,
-                execution_date=ti_data['execution_date']
-            )
+    tis = [
+        make_ti(**obj_data)
+        for obj_class, obj_data, _ in AIRFLOW_DATA
+        if obj_class is TaskInstance
+    ]
+    airflow_session.add_all([ti for ti in tis if ti])
+    airflow_session.flush()
 
-        tis = [
-            make_ti(obj_data)
-            for obj_class, obj_data, _ in AIRFLOW_DATA
-            if obj_class is TaskInstance
-        ]
-        session.add_all([ti for ti in tis if ti])
+    # Use XCom.set to handle value serialization
+    xcoms = [obj_data.copy() for obj_class, obj_data, _ in AIRFLOW_DATA if obj_class is XCom]
+    for xcom in xcoms:
+        execution_date = xcom.pop('execution_date')
+        run_id = (airflow_session.query(DagRun.run_id)
+                  .filter(DagRun.dag_id == xcom['dag_id'],
+                          DagRun.execution_date == execution_date)
+                  .scalar()
+                  )
+        XCom.set(**xcom, run_id=run_id, session=airflow_session)
 
-        def make_log(log_data):
-            log = Log(task_instance=None, **log_data)
-            # dttm is set by __init__, override it
-            log.dttm = log_data['dttm']
-            return log
+    def make_log(log_data):
+        log = Log(task_instance=None, **log_data)
+        # dttm is set by __init__, override it
+        log.dttm = log_data['dttm']
+        return log
 
-        logs = [
-            make_log(obj_data)
-            for obj_class, obj_data, _ in AIRFLOW_DATA
-            if obj_class is Log
-        ]
-        session.add_all(logs)
-
-    yield
-    with create_session() as session:
-        session.query(DagRun).delete()
-        session.query(Log).delete()
-        session.query(TaskInstance).delete()
-        session.query(XCom).delete()
+    logs = [
+        make_log(obj_data)
+        for obj_class, obj_data, _ in AIRFLOW_DATA
+        if obj_class is Log
+    ]
+    airflow_session.add_all(logs)
+    airflow_session.commit()
 
 
 @pytest.mark.usefixtures('make_airflow_objects')
 @pytest.mark.parametrize(
     'obj',
-    [pytest.param(obj, id=f'{class_name}, print') for class_name, obj in DATABASE_OBJECTS.items()] +
-    [pytest.param(obj, id=f'{class_name}, no print') for class_name, obj in DATABASE_OBJECTS.items()]
+    [pytest.param(obj, id=class_name) for class_name, obj in DATABASE_OBJECTS.items()]
 )
-@provide_session
-def test_airflow_db_cleanup(dagrun, obj, session=None):
+def test_airflow_db_cleanup(dag_run, obj: dict, airflow_session):
     airflow_db_model = obj['airflow_db_model']
     task_id = f'cleanup_{airflow_db_model.__name__}'
     ti = TaskInstance(
@@ -372,9 +391,9 @@ def test_airflow_db_cleanup(dagrun, obj, session=None):
             f: getattr(obj, f)
             for f in compare_fields[airflow_db_model]
         }
-        for obj in session.query(airflow_db_model)
-            .filter(airflow_db_model.dag_id != db_cleanup_dag.dag_id)
-            .all()
+        for obj in airflow_session.query(airflow_db_model)
+        .filter(airflow_db_model.dag_id != db_cleanup_dag.dag_id)
+        .all()
     ]
 
     assert results == expected
@@ -382,15 +401,14 @@ def test_airflow_db_cleanup(dagrun, obj, session=None):
 
 @pytest.mark.usefixtures('make_airflow_objects')
 @pytest.mark.parametrize('obj', [pytest.param(obj, id=class_name) for class_name, obj in DATABASE_OBJECTS.items()])
-@provide_session
-def test_airflow_db_cleanup_no_delete(dagrun, obj, session=None):
+def test_airflow_db_cleanup_no_delete(dag_run, obj: dict, airflow_session):
     airflow_db_model = obj['airflow_db_model']
 
     def make_obj(item):
         obj_dict = {f: getattr(item, f) for f in compare_fields[airflow_db_model]}
         return frozenset(obj_dict.items())
 
-    before = {make_obj(obj) for obj in session.query(airflow_db_model).all()}
+    before = {make_obj(obj) for obj in airflow_session.query(airflow_db_model).all()}
 
     task_id = f'cleanup_{airflow_db_model.__name__}'
     ti = TaskInstance(
@@ -400,7 +418,7 @@ def test_airflow_db_cleanup_no_delete(dagrun, obj, session=None):
     ti.run(ignore_all_deps=True)
     after = {
         make_obj(obj)
-        for obj in session.query(airflow_db_model)
+        for obj in airflow_session.query(airflow_db_model)
             .filter(airflow_db_model.dag_id != db_cleanup_dag.dag_id)
             .all()
     }

--- a/test/dags/test_airflow_log_cleanup.py
+++ b/test/dags/test_airflow_log_cleanup.py
@@ -4,12 +4,13 @@ from datetime import datetime
 import pytest
 from airflow.models import TaskInstance, XCom, DagRun
 from airflow.utils.state import State
+from airflow.utils.types import DagRunType
 from pendulum import DateTime, UTC
 
 from maintenance_dags import settings
 from maintenance_dags.airflow_log_cleanup import log_cleanup_dag, XCOM_LOG_FILES_KEY
 
-EXECUTION_DATE = DateTime(2020, 7, 18, 6, tzinfo=UTC)
+EXECUTION_DATE = DateTime(2024, 7, 18, 6, tzinfo=UTC)
 
 
 def create_file_with_st_mtime(py_fake_fs, full_path, dt):
@@ -21,13 +22,13 @@ def create_file_with_st_mtime(py_fake_fs, full_path, dt):
 
 
 @pytest.fixture()
-def dagrun(airflow_session):
-    dag_run = log_cleanup_dag.create_dagrun(
-        run_id=f'test_airflow_log_cleanup__{datetime.utcnow()}',
+def dag_run(airflow_session) -> DagRun:
+    return log_cleanup_dag.create_dagrun(
+        run_type=DagRunType.SCHEDULED,
         execution_date=EXECUTION_DATE,
         state=State.RUNNING,
+        session=airflow_session,
     )
-    return dag_run
 
 
 @pytest.mark.parametrize('log_files_to_create, older_than_date, expected', [
@@ -61,8 +62,7 @@ def dagrun(airflow_session):
         id='files with nothing to delete',
     ),
 ])
-def test_check_old_log_files(mocker, fs, dagrun, log_files_to_create, older_than_date, expected):
-    dagrun: DagRun
+def test_check_old_log_files(mocker, fs, dag_run, log_files_to_create: dict, older_than_date, expected):
     fs.create_dir(settings.LOG_DIR)
     mocker.patch('maintenance_dags.airflow_log_cleanup.x_days_ago', return_value=older_than_date)
 
@@ -73,8 +73,8 @@ def test_check_old_log_files(mocker, fs, dagrun, log_files_to_create, older_than
         log_files.append(file_name)
 
     ti = TaskInstance(
-        task=dagrun.dag.get_task('check_old_log_files'),
-        execution_date=dagrun.execution_date,
+        task=dag_run.dag.get_task('check_old_log_files'),
+        execution_date=dag_run.execution_date,
     )
     ti.set_state(State.NONE)
     ti.run(ignore_all_deps=True)
@@ -99,7 +99,7 @@ def test_check_old_log_files(mocker, fs, dagrun, log_files_to_create, older_than
     pytest.param({
         'log1.txt': datetime(2020, 1, 1),
         'log2.txt': datetime(1999, 12, 12),
-        'log3.txt': datetime.utcnow(),
+        'log3.txt': datetime.now(),
     }, id='2 old, 1 new, no subpaths'),
     pytest.param({
         'log1.txt': datetime(2020, 1, 1),
@@ -112,7 +112,7 @@ def test_check_old_log_files(mocker, fs, dagrun, log_files_to_create, older_than
         'that/other/path/log4.txt': datetime(2020, 1, 1),
     }, id='multiple subpaths'),
 ])
-def test_delete_old_files(fs, airflow_session, dagrun, log_paths):
+def test_delete_old_files(fs, airflow_session, dag_run, log_paths: dict):
     # All additional_files should remain after the task has completed
     fs.create_dir(settings.LOG_DIR)
 
@@ -127,11 +127,11 @@ def test_delete_old_files(fs, airflow_session, dagrun, log_paths):
         value=log_file_names,
         task_id='check_old_log_files',
         dag_id=log_cleanup_dag.dag_id,
-        execution_date=EXECUTION_DATE,
+        run_id=dag_run.run_id,
     )
     ti = TaskInstance(
-        task=dagrun.dag.get_task('delete_old_log_files'),
-        execution_date=dagrun.execution_date,
+        task=dag_run.dag.get_task('delete_old_log_files'),
+        run_id=dag_run.run_id,
     )
     ti.set_state(State.NONE)
     ti.run(ignore_all_deps=True)


### PR DESCRIPTION
After merging, we'll bump the version to 0.2.3 so that other repos can start using it. We should also probably merge develop into master, which was never done for v0.2.2.

Most of the changes on this PR are just to handle Airflow's SQLAlchemy structure, as TaskInstances now have a foreign key constraint on DagRun and XComs have a foreign key constraint on TaskInstance. The actual requirements of the ticket [NDWH-3813](https://bridgecorp.atlassian.net/browse/NDWH-3813) are in the last commit, [here](https://github.com/oneaudience/airflow-maintenance-dags/pull/4/commits/a590c827626ffa8ea52dc64ce7819ea77ff50fda).

[NDWH-3813]: https://bridgecorp.atlassian.net/browse/NDWH-3813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ