### PR TITLE
Update airflow_log_cleanup to use UTC

### DIFF
--- a/src/maintenance_dags/airflow_db_cleanup.py
+++ b/src/maintenance_dags/airflow_db_cleanup.py
@@ -36,5 +36,5 @@ with DAG(
     )
     clean_db = BashOperator(
         task_id='clean_db',
-        bash_command=f"airflow db clean --clean-before-timestamp '{calc_max_date.output}'"
+        bash_command=f"airflow db clean --clean-before-timestamp '{calc_max_date.output}' --yes"
     )

--- a/src/maintenance_dags/airflow_log_cleanup.py
+++ b/src/maintenance_dags/airflow_log_cleanup.py
@@ -3,7 +3,6 @@ An Airflow maintenance DAG that cleans out the local Airflow log files older tha
 `settings.MAX_LOG_fILE_AGE`.
 """
 import os
-from datetime import datetime, timedelta
 from pathlib import Path
 
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
@@ -11,20 +10,6 @@ from airflow.sdk import DAG
 from pendulum import DateTime
 
 from maintenance_dags import settings
-
-
-def x_days_ago(dt, num_days):
-    """
-    Returns a new date that is num_months before the specified date
-
-    :param dt: date to modify
-    :param num_days: number of days to subtract
-    :type dt: datetime
-    :type num_days: int
-    :return: dt - num_months
-    :rtype: datetime
-    """
-    return dt - timedelta(days=num_days)
 
 
 def check_for_old_log_files(max_age: int, *, task) -> list[str]:
@@ -37,7 +22,7 @@ def check_for_old_log_files(max_age: int, *, task) -> list[str]:
     """
     log = task.log
     files_to_delete = []
-    older_than_date = x_days_ago(DateTime.utcnow(), max_age)
+    older_than_date = DateTime.utcnow().subtract(days=max_age)
 
     log.info(f'Looking for log files older than {older_than_date.isoformat()}')
     # We use os.walk instead of os.listdir because there may be subdirectories
@@ -45,7 +30,7 @@ def check_for_old_log_files(max_age: int, *, task) -> list[str]:
     for root, _, files in os.walk(settings.LOG_DIR):
         for filename in files:
             file_name = os.path.join(root, filename)
-            last_modified_time = datetime.fromtimestamp(Path(file_name).stat().st_mtime)
+            last_modified_time = DateTime.fromtimestamp(Path(file_name).stat().st_mtime)
             if last_modified_time <= older_than_date:
                 files_to_delete.append(file_name)
 
@@ -72,7 +57,7 @@ def delete_files(files_to_delete: list[str], *, task):
 
 with DAG(
         dag_id='airflow_log_cleanup',
-        start_date=datetime(2021, 9, 1),
+        start_date=DateTime.create(2021, 9, 1),
         schedule='@monthly',
         catchup=False,
         tags={'airflow-maintenance-dags'},

--- a/test/dags/test_airflow_db_cleanup.py
+++ b/test/dags/test_airflow_db_cleanup.py
@@ -10,7 +10,7 @@ from airflow.sdk import Context, DagRunState
 from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 from airflow.sdk.execution_time.xcom import XCom
 from airflow.utils.types import DagRunType
-from pendulum import UTC, DateTime
+from pendulum import UTC, DateTime, parse
 
 from maintenance_dags.airflow_db_cleanup import db_cleanup_dag
 
@@ -77,4 +77,12 @@ def test_airflow_db_cleanup():
     )
 
     bash_command = re.split(r'\s+', cast(BashOperator, rendered).bash_command)
-    assert bash_command == ['airflow', 'db', 'clean', '--clean-before-timestamp', repr(timestamp)]
+    # The CLI parser will return a namespace including the subcommand,
+    # but not the command, so check the command directly.
+    assert bash_command[:2] == ['airflow', 'db']
+    from airflow.cli import cli_parser
+    args = cli_parser.get_parser().parse_args(bash_command[1:])
+    assert args.subcommand == 'clean'
+    assert args.clean_before_timestamp == parse(timestamp)
+    assert args.yes
+    assert not args.dry_run

--- a/test/dags/test_airflow_log_cleanup.py
+++ b/test/dags/test_airflow_log_cleanup.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import cast
 
+import pendulum
 import pytest
 from airflow.models import DagRun, XCom
 from airflow.providers.standard.operators.python import PythonOperator, ShortCircuitOperator
@@ -36,11 +37,11 @@ def dag_run(airflow_session) -> DagRun:
     )
 
 
-@pytest.mark.parametrize('log_files_to_create, older_than_date, expected', [
-    pytest.param({}, datetime(2021, 1, 1), [], id='no files'),
+@pytest.mark.parametrize('log_files_to_create, fake_now, expected', [
+    pytest.param({}, DateTime.create(2021, 1, 31), [], id='no files'),
     pytest.param(
         {'log1.txt': datetime(2020, 1, 1)},
-        datetime(2021, 1, 1),
+        DateTime.create(2021, 1, 31),
         ['log1.txt'],
         id='single file',
     ),
@@ -51,7 +52,7 @@ def dag_run(airflow_session) -> DagRun:
          'that/log4.txt': datetime(2021, 3, 1),
          'that/log5.txt': datetime(2018, 11, 12),
          },
-        datetime(2020, 3, 1),
+        DateTime.create(2020, 3, 31),
         ['log1.txt', 'log2.txt', 'this/log3.txt', 'that/log5.txt'],
         id='multiple files with subpaths',
     ),
@@ -62,14 +63,13 @@ def dag_run(airflow_session) -> DagRun:
          'that/log4.txt': datetime(2021, 3, 1),
          'that/log5.txt': datetime(2018, 11, 12),
          },
-        datetime(2005, 3, 1),
+        DateTime.create(2005, 3, 31),
         [],
         id='files with nothing to delete',
     ),
 ])
-def test_check_old_log_files(mocker, fs, log_files_to_create: dict, older_than_date, expected):
+def test_check_old_log_files(fs, log_files_to_create: dict, fake_now, expected):
     fs.create_dir(settings.LOG_DIR)
-    mocker.patch('maintenance_dags.airflow_log_cleanup.x_days_ago', return_value=older_than_date)
 
     log_files = []
     for file_name, creation_timestamp in log_files_to_create.items():
@@ -78,7 +78,8 @@ def test_check_old_log_files(mocker, fs, log_files_to_create: dict, older_than_d
         log_files.append(file_name)
 
     task: ShortCircuitOperator = log_cleanup_dag.get_task('check_old_log_files')
-    result = task.python_callable(**task.op_kwargs, task=task)
+    with pendulum.travel_to(fake_now, freeze=True):
+        result = task.python_callable(**task.op_kwargs, task=task)
     expected = [
         os.path.join(settings.LOG_DIR, file_name)
         for file_name in expected


### PR DESCRIPTION
The current code uses a combination of datetime.datetime and pendulum.DateTime. This results in the error "TypeError: can't compare offset-naive and offset-aware datetimes"

The DAG now uses pendulum.DateTime consistently, treating every timestamp as UTC.